### PR TITLE
#88 - Prevent multiple definitions of the same language when creating…

### DIFF
--- a/src/main/java/de/dataelementhub/rest/controller/v1/NamespaceController.java
+++ b/src/main/java/de/dataelementhub/rest/controller/v1/NamespaceController.java
@@ -154,7 +154,7 @@ public class NamespaceController {
       return new ResponseEntity<>(httpHeaders, HttpStatus.CREATED);
     } catch (IllegalAccessException e) {
       return new ResponseEntity<>(HttpStatus.FORBIDDEN);
-    } catch (IOException e) {
+    } catch (IOException | IllegalArgumentException e) {
       return new ResponseEntity<>(e.getMessage(), HttpStatus.UNPROCESSABLE_ENTITY);
     }
   }
@@ -267,11 +267,11 @@ public class NamespaceController {
       return new ResponseEntity<>(httpHeaders, HttpStatus.NO_CONTENT);
     } catch (IllegalAccessException e) {
       return new ResponseEntity<>(HttpStatus.FORBIDDEN);
-    } catch (UnsupportedOperationException | IllegalArgumentException e) {
+    } catch (UnsupportedOperationException e) {
       return new ResponseEntity<>(HttpStatus.NOT_ACCEPTABLE);
     } catch (NoSuchMethodException e) {
       return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
-    } catch (IOException | IllegalStateException e) {
+    } catch (IOException | IllegalArgumentException | IllegalStateException e) {
       return new ResponseEntity<>(e.getMessage(), HttpStatus.UNPROCESSABLE_ENTITY);
     } catch (NoSuchElementException nse) {
       return new ResponseEntity<>(


### PR DESCRIPTION
**What's in the PR**
* When creating a namespace, check if only one definition per language is present. if this is not the case throw an exception.

**How to test manually**
* Check if creating/updating a namespace with two or more definitions of the same language throws an exception
* test with [model](https://github.com/imi-frankfurt/dataelementhub.model/pull/114)
* close #88 
